### PR TITLE
fix bugs in three functions

### DIFF
--- a/R/carnival_analysis.R
+++ b/R/carnival_analysis.R
@@ -494,7 +494,7 @@ run_carnival_and_create_graph <- function(source_df,
 #' @examples
 convert_output_nodes_in_next_input <- function(carnival_result){
   nodes <- carnival_result$nodes_df
-  formatted_nodes <- nodes %>% dplyr::select(gene_name, final_score = carnival_activity, mf, method)
+  formatted_nodes <- nodes %>% dplyr::select(UNIPROT, gene_name, final_score = carnival_activity, mf, method)
   return(formatted_nodes)
 }
 

--- a/R/go_term_managment.R
+++ b/R/go_term_managment.R
@@ -31,7 +31,9 @@ molecular_function_annotation <- function(inferred_proteins_dataset, organism){
   inferred_proteins_dataset$mf[is.na(inferred_proteins_dataset$mf) & grepl('SIGNOR-C', inferred_proteins_dataset$UNIPROT)] <- 'complex'
   inferred_proteins_dataset$mf[is.na(inferred_proteins_dataset$mf) & grepl('SIGNOR-F', inferred_proteins_dataset$UNIPROT)] <- 'fusion protein'
   inferred_proteins_dataset$mf[is.na(inferred_proteins_dataset$mf)] <- 'other'
-  inferred_proteins_dataset$mf[inferred_proteins_dataset$method == 'user'] <- 'rec'
+  if ("method" %in% colnames(inferred_proteins_dataset)){
+    inferred_proteins_dataset$mf[inferred_proteins_dataset$method == 'user'] <- 'rec'
+  }
 
   return(inferred_proteins_dataset)
 }

--- a/R/phenoscore.R
+++ b/R/phenoscore.R
@@ -422,8 +422,8 @@ phenoscore_computation <- function(proteins_df,
 
           # handling NA in gene_name column
 
-          true_table_from <- igraph::V(sp_graph)$gene_name == combinatios[1,i]
-          true_table_to <- igraph::V(sp_graph)$gene_name == combinatios[2,i]
+          true_table_from <- igraph::V(sp_graph)$name == combinatios[1,i]
+          true_table_to <- igraph::V(sp_graph)$name == combinatios[2,i]
 
           true_table_from[is.na(true_table_from)] <- FALSE
           true_table_to[is.na(true_table_to)] <- FALSE
@@ -455,10 +455,10 @@ phenoscore_computation <- function(proteins_df,
           # print('i reverse')
           # print(i)
 
-          true_table_from_rev <- igraph::V(sp_graph)$gene_name == combinatios[2,i]
+          true_table_from_rev <- igraph::V(sp_graph)$name == combinatios[2,i]
           true_table_from_rev[is.na(true_table_from_rev)] <- FALSE
 
-          true_table_to_rev <- igraph::V(sp_graph)$gene_name == combinatios[1,i]
+          true_table_to_rev <- igraph::V(sp_graph)$name == combinatios[1,i]
           true_table_to_rev[is.na(true_table_to_rev)] <- FALSE
 
           if(sum(true_table_from_rev) == 0 | sum(true_table_to_rev) == 0){
@@ -612,6 +612,8 @@ phenoscore_computation <- function(proteins_df,
 
   if(flag == 'mouse'){
     results.table_reg$regulators <- stringr::str_to_title(results.table_reg$regulators)
+    igraph::V(sp_graph)$name <- stringr::str_to_title(igraph::V(sp_graph)$name)
+
   }
 
   # Create a network with the phenotypes linked


### PR DESCRIPTION
Dear SignalingProfile team,

First of all, Thank you all very much for providing this excellent tool.

Recently, @styanova and I, mostly @styanova, tried it out and found the results were very promising. However, we encountered some bugs during the exploration, and we thought it might be a good idea to address them and contribute to the repo.

Basically we modified four places:
1.  In the `molecular_function_annotation`, a column called `method` is assumed to exist in `inferred_proteins_dataset`. However, by following the tutorial, this column is missing and the function complains :
  ```
  Warning message:
      Unknown or uninitialised column: `method`. 
  ```
Therefore, we wrapped the line related to the `method` column in an if statement. 

2. In `convert_output_nodes_in_next_input `, the column `UNIPORT` is not included in the output dataframe and it returns only 4 columns. However, when using the output as `source_df`  of `run_carnival_and_create_graph`, `check_CARNIVAL_inputs` will complain because it requires the `source_df` to have more than 4 columns `stopifnot(ncol(source_df) > 4)`. We added a column `UNIPORT` in the output dataframe of `convert_output_nodes_in_next_input`. Another workaround is to modify the stop criteria in `check_CARNIVAL_inputs` as `stopifnot(ncol(source_df) >= 4)`. Please feel free to revert this change.

3. In `phenoscore_computation`, `V(sp_graph)$gene_name` is called 4 times while upon checking the igraph object `sp_graph` doesn't have a vertex attribute called `gene_name` and this call returned `NULL`. Therefore, we replaced all `V(sp_graph)$gene_name` with `V(sp_graph)$name`.

4. In `phenoscore_computation`, if `flag = 'mouse'`, the `gene_name` column in `proteins_df` and the `name` attribute in `V(sp_graph)` will be changed using `str_to_upper`. However, at the end of the function, only the gene names in the output dataframe is changed back using `str_to_title`, but not `spgraph`. This called error when building the output graph `pheno_graph` because gene names in the node list and edge list do not match.  Therefore, we added one line to also change the gene names in `spgraph` back.
```
Error in igraph::graph_from_data_frame(edges_df_pheno, vertices = node_df_pheno %>%  : 
  Some vertex names in edge list are not listed in vertex data frame
``` 

Best,
Dongze and Stefka